### PR TITLE
Added ability to specify directory as filenames argument

### DIFF
--- a/lib/m2j.js
+++ b/lib/m2j.js
@@ -82,8 +82,18 @@ exports.parse = function(filenames, options)
     // http://i.imgur.com/EnXB9aA.jpg
 
     filenames.forEach(function(f) {
-        var m = processFile(f, options.width, options.content);
-        parse_all_the_files[m.basename] = m.metadata;
+        if(fs.lstatSync(f).isDirectory()) {
+            var dir = f;
+            filenames = fs.readdirSync(f);
+            filenames.forEach(function(f2) {
+                f2 = dir + "/" + f2;
+                var m = processFile(f2, options.width);
+                parse_all_the_files[m.basename] = m.metadata;
+            });
+        } else {
+            var m = processFile(f, options.width);
+            parse_all_the_files[m.basename] = m.metadata;
+        }
     });
 
     var json;


### PR DESCRIPTION
Steps to test: 

1) Specify a directory of markdown files and m2j should output glob
2) Specify a single file and should still work.