### PR TITLE
Ensure content options work with the parse method

### DIFF
--- a/lib/m2j.js
+++ b/lib/m2j.js
@@ -87,11 +87,11 @@ exports.parse = function(filenames, options)
             filenames = fs.readdirSync(f);
             filenames.forEach(function(f2) {
                 f2 = dir + "/" + f2;
-                var m = processFile(f2, options.width);
+                var m = processFile(f2, options.width, options.content);
                 parse_all_the_files[m.basename] = m.metadata;
             });
         } else {
-            var m = processFile(f, options.width);
+            var m = processFile(f, options.width, options.content);
             parse_all_the_files[m.basename] = m.metadata;
         }
     });


### PR DESCRIPTION
For some reason, the options weren't passed on as expected.
This fixes some of the tests (coupled with #16 it makes all tests pass!)