### PR TITLE
Use contributed solutions for String.trim and String.truncate

### DIFF
--- a/lib/m2j.js
+++ b/lib/m2j.js
@@ -6,10 +6,6 @@ var moment = require('moment'),
     fs = require('fs'),
     yaml = require('yaml-front-matter');
 
-String.prototype.trim = function () {
-    return this.replace(/^\s+|\s+$/g, '');
-};
-
 // Truncate a string and add a horizontal ellipses after n charcters
 String.prototype.truncate =
     function (n) {

--- a/lib/m2j.js
+++ b/lib/m2j.js
@@ -2,33 +2,10 @@
 'use strict';
 
 var moment = require('moment'),
+    truncate = require('lodash.truncate'),
     path = require('path'),
     fs = require('fs'),
     yaml = require('yaml-front-matter');
-
-// Truncate a string and add a horizontal ellipses after n charcters
-String.prototype.truncate =
-    function (n) {
-
-        var temp = this.trim();
-
-        if (temp.length <= n || n === 0) {
-            return temp;
-        }
-
-        // 1. Get the first n characters.
-        temp = temp.substr(0, n);
-
-        // 2. Strip off the last non-whitespace sequence of characters (to find a word boundary)
-        // tested at http://regexpal.com
-        var re = temp.match(new RegExp("[^\\s]+$"));
-
-        if (re !== null) {
-            temp = temp.substr(0, temp.length - re[0].length);
-        }
-
-        return temp + '…'; // or consider '&hellip;';
-    };
 
 // Side effects:
 // - Root node of JSON is files key mapping to a dictionary of files
@@ -46,7 +23,8 @@ function processFile(filename, width, content)
         // If width is truthy (is defined and and is not 0).
         if (width) {
           //Max of WIDTH chars, snapped to word boundaries, and trim leading whitespace
-          _metadata.preview = _metadata['__content'].truncate(width).replace(/^\s+/, '');
+          var truncate_options = {length: width, separator: /\s/, omission: ' …'};
+          _metadata.preview = truncate(_metadata['__content'].trim(), truncate_options);
         }
 
         // If the command line option is provided keep the entire content in field 'content'
@@ -109,7 +87,4 @@ exports.parse = function(filenames, options)
     }
 };
 })();
-
-
-
 

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
   "license": "BSD",
   "dependencies": {
     "commander": "~1.1.1",
-    "yaml-front-matter": "~1.0.3",
-    "moment": "~2.0.0"
+    "lodash.truncate": "^4.4.2",
+    "moment": "~2.0.0",
+    "yaml-front-matter": "~1.0.3"
   },
   "devDependencies": {
+    "glob": "*",
     "mocha": "*",
-    "should": "*",
-    "glob": "*"
+    "should": "*"
   }
 }


### PR DESCRIPTION
I think we could drop our custom `String.trim` for the default ES5 solution.
And we could leverage the lightweight `lodash.truncate` for our truncate needs.

All tests pass in this branch :)