### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "commander": "^2.9.0",
     "lodash.truncate": "^4.4.2",
     "moment": "~2.0.0",
-    "yaml-front-matter": "~1.0.3"
+    "yaml-front-matter": "^3.4.0"
   },
   "devDependencies": {
     "glob": "*",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "BSD",
   "dependencies": {
-    "commander": "~1.1.1",
+    "commander": "^2.9.0",
     "lodash.truncate": "^4.4.2",
     "moment": "~2.0.0",
     "yaml-front-matter": "~1.0.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "lodash.truncate": "^4.4.2",
-    "moment": "~2.0.0",
+    "moment": "^2.17.1",
     "yaml-front-matter": "^3.4.0"
   },
   "devDependencies": {

--- a/test/fixtures/fiddler.md
+++ b/test/fixtures/fiddler.md
@@ -1,7 +1,7 @@
 ---
 title: The Fiddler
 author: herman
-date: March 13 2013 1:00 pm
+date: 2013-03-13 13:00
 template: article.jade
 tags: 
   - crab


### PR DESCRIPTION
This PR will update all the dependencies to the latest version (as of 2 weeks ago).
It fixes one test for deprecated moment date formats (see #20 ).
Everything else passes.