### PR TITLE
added fullpath option

### DIFF
--- a/lib/m2j.js
+++ b/lib/m2j.js
@@ -14,7 +14,7 @@ const yaml = require('yaml-front-matter');
 // - .__content is removed (potentially too large)
 // - if .date is detected, a formated date is added as .dateFormatted
 
-const processFile = function(filename, width, content) {
+const processFile = function(filename, width, content, fullpath) {
   const _basename = path.basename(filename, path.extname(filename));
 
   const contents = fs.readFileSync(filename, {encoding: 'utf-8'});
@@ -44,6 +44,10 @@ const processFile = function(filename, width, content) {
     _metadata.iso8601Date = moment(_metadata.date).format();
   }
 
+  if (typeof(fullpath) != 'undefined' && fullpath === true) {
+    _metadata.fullpath = filename;
+  }
+
   _metadata.basename = _basename;
 
   return {
@@ -70,7 +74,8 @@ exports.parse = function(filenames, options) {
       .reduce((collection, filenames) => collection.concat(filenames), []);
 
   files
-      .map((file) => processFile(file, options.width, options.content))
+      .map((file) => processFile(file, options.width,
+          options.content, options.fullpath))
       .forEach((data) => {
         parseAllTheFiles[data.basename] = data.metadata;
       });

--- a/test/test.js
+++ b/test/test.js
@@ -84,4 +84,15 @@ describe('markdown-to-json', function() {
       results.trim().should.equal(json);
     });
   });
+
+  describe('with fullpath enabled', function() {
+    it('should return valid json with reference to the full pathname', function() {
+      options.width = 0;
+      options.content = true;
+      options.fullpath = true;
+      const results = m2j.parse(['test/fixtures/bellflower.md'], options);
+      const json = JSON.parse(results.trim());
+      json[Object.keys(json)[0]].fullpath.should.equal('test/fixtures/bellflower.md');
+    });
+  });
 });


### PR DESCRIPTION
This PR introduces the option to return the full file path for a parsed piece of content. By adding the `fullpath` option to the configuration and setting it to `true`, the results metadata will include a `fullpath` property. 

This change was inspired by work I did using this library to implement documentation search. In order to make the results clickable, we needed the full path for the file. I hacked together a solution for that project, but felt like this change might benefit others using this library. 

Added a test to support this new functionality as well. 